### PR TITLE
fix: ensure basemap loads in cloud dev

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig, splitVendorChunkPlugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import { visualizer } from 'rollup-plugin-visualizer';
-const backend = process.env.VITE_BACKEND_URL || 'http://localhost:4000'; // configurable in dev
+// Use explicit IPv4 loopback by default to avoid IPv6 resolution issues that
+// prevented the map proxy from being reached in some environments.
+const backend =
+  process.env.VITE_BACKEND_URL || 'http://127.0.0.1:4000'; // configurable in dev
 
 // Custom plugin to strip the eval usage in protobufjs's minimal build (inquire helper)
 // to silence Vite's eval warning while keeping module behavior (returns null for optional deps).


### PR DESCRIPTION
## Summary
- use 127.0.0.1 for Vite dev backend to prevent IPv6 resolution issues that blocked basemap tiles when running `cloud-dev`

## Testing
- `pnpm test` *(fails: App mode permalink + env gating > accepts #mode=3d (hash fallback) when enabled; HTMLCanvasElement.prototype.getContext not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6e3633c88323bcec8b70c71620f0