### PR TITLE
Manage project environment variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12266,6 +12266,7 @@
         "react-dom": "^18.3.1",
         "recharts": "^3.1.2",
         "use-debounce": "^10.0.5",
+        "zod": "^4.1.3",
         "zustand": "^4.5.5"
       },
       "devDependencies": {
@@ -12308,7 +12309,15 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "web/node_modules/zod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.3.tgz",
+      "integrity": "sha512-1neef4bMce1hNTrxvHVKxWjKfGDn0oAli3Wy1Uwb7TRO1+wEwoZUZNP1NXIEESybOBiFnBOhI6a4m6tCLE8dog==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }
-

--- a/web/package.json
+++ b/web/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^18.3.1",
     "recharts": "^3.1.2",
     "use-debounce": "^10.0.5",
+    "zod": "^4.1.3",
     "zustand": "^4.5.5"
   },
   "devDependencies": {
@@ -46,11 +47,11 @@
     "axe-core": "^4.10.0",
     "canvas": "^3.2.0",
     "jsdom": "^26.1.0",
-    "source-map-explorer": "^2.5.3",
     "postcss": "^8.5.6",
     "postcss-preset-mantine": "^1.18.0",
     "postcss-simple-vars": "^7.0.1",
     "rollup-plugin-visualizer": "^5.12.0",
+    "source-map-explorer": "^2.5.3",
     "typescript": "^5.5.4",
     "vite": "^6.3.5",
     "vitest-axe": "^0.1.0"

--- a/web/src/map/cesium/CesiumGlobe.tsx
+++ b/web/src/map/cesium/CesiumGlobe.tsx
@@ -119,26 +119,18 @@ export function CesiumGlobe() {
           import.meta.env.VITE_GIBS_WMTS_TILE_URL ||
           '/api/gibs/tile/GOES-East_ABI_GeoColor/{z}/{y}/{x}.jpg?time={time}';
         if (!existing) {
-          const url = template
-            .replace('{z}', String(z))
-            .replace('{y}', String(y))
-            .replace('{x}', String(x))
-            .replace('{time}', encodeURIComponent(timeIso));
+          // For Cesium, we use a template that will be filled by the tile provider
+          // The {z}, {y}, {x} placeholders are handled by Cesium internally
           const provider = new UrlTemplateImageryProvider({
-            url,
+            url: template,
             credit: 'GOES-East GeoColor (NASA GIBS)',
           });
           layers.addImageryProvider(provider, 1);
         } else {
           // Recreate layer with new time (simpler than mutating template)
           layers.remove(existing, true);
-          const url = template
-            .replace('{z}', String(z))
-            .replace('{y}', String(y))
-            .replace('{x}', String(x))
-            .replace('{time}', encodeURIComponent(timeIso));
           const provider = new UrlTemplateImageryProvider({
-            url,
+            url: template,
             credit: 'GOES-East GeoColor (NASA GIBS)',
           });
           layers.addImageryProvider(provider, 1);

--- a/web/src/ui/App.tsx
+++ b/web/src/ui/App.tsx
@@ -41,7 +41,6 @@ export default function App() {
     playbackCurrentTimeMs,
   } = useStore();
   
-  console.log('[App] Current mode:', mode, 'canUse3D:', canUse3D);
   const [flags, setFlags] = useState<{ enable3d: boolean }>({
     enable3d: false,
   });
@@ -63,7 +62,7 @@ export default function App() {
   // Until runtime flags are fetched, assume enabled to avoid premature downgrades in SSR/tests
   const canUse3D = envEnable && (flagsReady ? flags.enable3d : true);
   
-  console.log('[App] Current mode:', mode, 'canUse3D:', canUse3D, 'requested3d:', requested3d);
+  console.log('[App] Current mode:', mode, 'canUse3D:', canUse3D);
 
   // Update mode from location on mount to handle hash changes after store initialization
   useEffect(() => {

--- a/web/src/util/store.ts
+++ b/web/src/util/store.ts
@@ -69,6 +69,7 @@ type Store = TimeState & {
   togglePlaying: () => void;
   setView: (v: Partial<ViewState>) => void;
   setMode: (m: '2d' | '3d') => void;
+  updateModeFromLocation: () => void;
   toggleGibsGeocolor3d: () => void;
   setGibsTimestamps: (ts: string[]) => void;
   setGibsSelectedTime: (t: string | null) => void;


### PR DESCRIPTION
### What & Why

Resolved critical build and TypeScript errors in the web application to ensure it compiles successfully and adheres to type safety. This makes the project stable and ready for further development and deployment.

### Changes

- Added `zod` as a missing dependency to `web/package.json`.
- Corrected the usage of `UrlTemplateImageryProvider` in `web/src/map/cesium/CesiumGlobe.tsx` to allow Cesium to handle tile coordinate placeholders (`{z}/{y}/{x}`) internally.
- Fixed a `console.log` statement in `web/src/ui/App.tsx` that referenced a variable before its declaration.
- Updated the `Store` type interface in `web/src/util/store.ts` to include the `updateModeFromLocation` function, resolving a TypeScript error.

### Risk / Rollback

- Risk: Low. Changes are primarily corrective for build and type errors, aligning with intended library usage and type definitions.
- Rollback: `git revert <sha>`

### Tests / Evidence

```bash
pnpm run validate:catalog
pnpm run validate:inventory
pnpm -w run typecheck && pnpm -w run test
```
All commands passed successfully after the changes.

### Checklist

- [x] No secrets in diff
- [x] No breaking route/contract changes
- [ ] Docs updated (if needed)

## Summary
Resolved build and TypeScript errors in the web application to ensure correct functionality and type safety.

## Change Type

- [x] modify
- [x] add (for `zod` dependency)

## Areas / Categories Impacted

web, build, type-checking, dependencies, map (Cesium)

## Vision Alignment

Improved developer experience and application stability by resolving critical build and type errors, ensuring the project is functional and maintainable.

## Relates to VISION.md goals (list IDs & titles):

N/A

## Rationale

The application was failing to build and type-check due to a missing dependency and several TypeScript errors. These fixes are essential to bring the project to a stable state, allowing for successful compilation, testing, and further development.

## Implementation Notes

- `zod` was added as a direct dependency to `web/package.json` as it was being imported but not declared.
- `CesiumGlobe.tsx` was updated to correctly use `UrlTemplateImageryProvider` by passing the template string directly, allowing Cesium to handle the `{z}/{y}/{x}` placeholders.
- `App.tsx` had a `console.log` statement reordered to avoid referencing an undeclared variable.
- `store.ts` was updated to include `updateModeFromLocation` in the `Store` type, resolving a TypeScript error.

## Risk

Risk level: low
Risk details and mitigation steps: The changes are primarily corrective and align with the intended usage of libraries and type definitions. The risk of introducing new issues is minimal.

## Cost Impact

Operational / infra cost impact: none

## Validation

Pre / post change checks performed (copy from logs):

- build:pass
- tests:pass
- typecheck:pass
- lint:pass

## Screenshots / Outputs (if UI or CLI)

N/A (internal build/type fixes)

## Follow Ups

- N/A

## Checklist

- [ ] Updated AGENTUPDATEHISTORY.jsonl entry (schema v2.0)
- [ ] Added/updated tests (Existing tests pass, no new tests added)
- [ ] Docs updated (README / RUNBOOK if required)
- [x] No secrets or credentials committed
- [x] Lint & type check pass locally

---
<a href="https://cursor.com/background-agent?bcId=bc-f7ae6740-f7ff-4f86-ad53-5b6fa261b340">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7ae6740-f7ff-4f86-ad53-5b6fa261b340">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

